### PR TITLE
Added support for ChartJS draw plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,8 @@ var chartJsOptions = {
     data: myData,
     options: myOptions
 }
-
 ```
-[ChartJS Plugin Documentation](http://www.chartjs.org/docs/#advanced-usage-creating-plugins)
 
-Read here to see what plugins you can write. In the context of drawing static images, ``beforeDraw`` and/or ``afterDraw`` methods makes most sense to implement.
+[Read here](http://www.chartjs.org/docs/#advanced-usage-creating-plugins) to see what plugins you can write. In the context of drawing static images, ``beforeDraw`` and/or ``afterDraw`` methods makes most sense to implement.
 
-[CanvasRenderingContext2D](https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D)
-
-Read here to see which methods are available for the ``ctx`` object.
+[Read here](https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D) to see which methods are available for the ``ctx`` object.

--- a/README.md
+++ b/README.md
@@ -63,3 +63,25 @@ method to release the native resources or you may leak memory:
 ```
 chartNode.destroy();
 ```
+
+## Adding draw plugins
+
+To use draw plugins, simply use the ``options`` object to add your plugins, like so:
+```
+var options = {
+    plugins: {
+        afterDraw: function (chart, easing) {
+            var self = chart.config;    /* Configuration object containing type, data, options */
+            var ctx = chart.chart.ctx;  /* Canvas context used to draw with */
+            ...
+        }
+    }
+}
+```
+[ChartJS Plugin Documentation](http://www.chartjs.org/docs/#advanced-usage-creating-plugins)
+
+Read here to see what plugins you can write. In this context of drawing static images, the ``beforeDraw`` and ``afterDraw`` method makes most sense to use.
+
+[CanvasRenderingContext2D](https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D)
+
+Read here to see which methods are available for the ``ctx`` object.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ chartNode.destroy();
 
 To use draw plugins, simply use the ``options`` object to add your plugins, like so:
 ```
-var options = {
+var myOptions = {
     plugins: {
         afterDraw: function (chart, easing) {
             var self = chart.config;    /* Configuration object containing type, data, options */
@@ -77,10 +77,17 @@ var options = {
         }
     }
 }
+
+var chartJsOptions = {
+    type: 'pie',
+    data: myData,
+    options: myOptions
+}
+
 ```
 [ChartJS Plugin Documentation](http://www.chartjs.org/docs/#advanced-usage-creating-plugins)
 
-Read here to see what plugins you can write. In this context of drawing static images, the ``beforeDraw`` and ``afterDraw`` method makes most sense to use.
+Read here to see what plugins you can write. In the context of drawing static images, ``beforeDraw`` and/or ``afterDraw`` methods makes most sense to implement.
 
 [CanvasRenderingContext2D](https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D)
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ chartNode.destroy();
 
 To use draw plugins, simply use the ``options`` object to add your plugins, like so:
 ```
-var myOptions = {
+var myChartOptions = {
     plugins: {
         afterDraw: function (chart, easing) {
             var self = chart.config;    /* Configuration object containing type, data, options */
@@ -80,8 +80,8 @@ var myOptions = {
 
 var chartJsOptions = {
     type: 'pie',
-    data: myData,
-    options: myOptions
+    data: myChartData,
+    options: myChartOptions
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -49,6 +49,9 @@ class ChartjsNode {
             global.document = window.document;
             global.window = window;
             const Chartjs = require('chart.js');
+            if(configuration.options.plugins) {
+                Chartjs.pluginService.register(configuration.options.plugins);
+            }
             this._window = window;
             debug('got window');
             this._disableDynamicChartjsSettings(configuration);


### PR DESCRIPTION
Added support for ChartJS draw plugins. Simply by adding the plugins object to the configuration object you can add draw plugins when drawing your chart.