### PR TITLE
Expose CanvasGradient and CanvasPattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 
 .vscode/
+.idea

--- a/index.js
+++ b/index.js
@@ -75,6 +75,11 @@ class ChartjsNode extends EventEmitter {
                     global[method] = window[method]
                 );
 
+                // canvas 1.x does not export these yet, 2.x does but it's not released yet
+                const bindings = require('canvas/lib/bindings');
+                global.CanvasGradient = bindings.CanvasGradient;
+                global.CanvasPattern = bindings.CanvasPattern;
+
                 global.CanvasRenderingContext2D = canvas.Context2d;
 
                 global.navigator = {


### PR DESCRIPTION
Greetings,

I got some fatal errors when generating a line chart. Seems as though chart.js expected CanvasGradient to exist globally, but it wasn't. It also appears that chart.js hasn't bothered exporting this until the (currently unreleased) 2.x branch. 

This PR adds CanvasCradient and CanvasPattern to global as well. Haven't seen any crashes since.

Thanks,
-Kevin